### PR TITLE
feat: Split configuration into two rulesets

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,5 @@
 module.exports = {
   rules: {
-    'react/react-in-jsx-scope': 'off',
-    'react/prop-types': 0,
-    'react/display-name': 0,
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-var-requires': 'warn',
@@ -15,13 +12,9 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true,
-    },
   },
   extends: [
     'eslint:recommended',
-    'plugin:react/recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
     'plugin:prettier/recommended',
@@ -33,11 +26,5 @@ module.exports = {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
   },
-  settings: {
-    react: {
-      pragma: 'React',
-      version: 'detect',
-    },
-  },
-  plugins: ['react', '@typescript-eslint', 'prettier', 'react-hooks'],
+  plugins: ['@typescript-eslint', 'prettier'],
 };

--- a/.eslintrc.react.js
+++ b/.eslintrc.react.js
@@ -1,0 +1,23 @@
+module.exports = {
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 0,
+    'react/display-name': 0,
+  },
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  extends: [
+    './index',
+    'plugin:react/recommended',
+  ],
+  settings: {
+    react: {
+      pragma: 'React',
+      version: 'detect',
+    },
+  },
+  plugins: ['react', 'react-hooks'],
+};

--- a/README.md
+++ b/README.md
@@ -10,12 +10,24 @@ $ npm install eslint @smartive/eslint-config -D
 
 ## Usage
 
-Create a `.eslintrc` file in the root of your project's directory (it should live where `package.json` does). Your `.eslintrc` file should look like this:
+Create a `.eslintrc` file in the root of your project's directory (it should live where `package.json` does). This package offers two different rulesets, on for plain TypeScript applications (`@smartive/eslint-config`) and a separate one for React applications (`@smartive/eslint-config`). Your `.eslintrc` file should look like this:
+
+### Plain TypeScript applications
 
 ```
 {
   "extends": [
     "@smartive/eslint-config"
+  ]
+}
+```
+
+### React applications
+
+```
+{
+  "extends": [
+    "@smartive/eslint-config/react"
   ]
 }
 ```

--- a/react.js
+++ b/react.js
@@ -1,0 +1,3 @@
+const eslintrc = require('./.eslintrc.react');
+
+module.exports = eslintrc;


### PR DESCRIPTION
BREAKING CHANGE: The configuration for React based applications changed from `@smartive/eslint-config` to `@smartive/eslint-config/react`. Make sure to update your `extend` option accordingly.