### PR TITLE
feat: Update all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
-    "eslint-config-prettier": "^7.2.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-react": "^7.23.2",
-    "eslint-plugin-react-hooks": "^4.2.0"
+    "@typescript-eslint/eslint-plugin": "^5.4.0",
+    "@typescript-eslint/parser": "^5.4.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-react": "^7.27.0",
+    "eslint-plugin-react-hooks": "^4.3.0"
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0"


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node v10 and lower - required node version is now `^12.22.0 || ^14.17.0 || >=16.0.0`