### PR TITLE
feat: disable rule @typescript-eslint/prefer-regexp-exec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ const rules = (react: boolean): Linter.RulesRecord => ({
   '@typescript-eslint/consistent-type-definitions': 'off',
   '@typescript-eslint/explicit-function-return-type': 'off',
   '@typescript-eslint/explicit-module-boundary-types': 'off',
+  '@typescript-eslint/prefer-regexp-exec': 'off',
   '@typescript-eslint/no-var-requires': 'warn',
   '@typescript-eslint/no-unused-vars': ['error'],
   '@typescript-eslint/no-floating-promises': ['error'],


### PR DESCRIPTION
IMO this rule does not improve readability rather than making it more complicated to work with regular expressions: https://typescript-eslint.io/rules/prefer-regexp-exec/